### PR TITLE
Fix naming for deprecated in PMCE.swift

### DIFF
--- a/Sources/WebSocketKit/PMCE.swift
+++ b/Sources/WebSocketKit/PMCE.swift
@@ -718,7 +718,7 @@ public final class PMCE: Sendable {
 
         
     /// websocket calls from handleIncoming as a server to handle client masked compressed frames. This was epxerimentally determined.
-    @available(*, deprecatred)
+    @available(*, deprecated)
     public func unmaskedDecompressedUnamsked(frame: WebSocketFrame) throws -> WebSocketFrame {
         
         if logging {


### PR DESCRIPTION
It's spelled incorrectly